### PR TITLE
allow for non-tensor kwargs in calculate_flops

### DIFF
--- a/calflops/flops_counter.py
+++ b/calflops/flops_counter.py
@@ -154,20 +154,19 @@ def calculate_flops(model,
 
     if kwargs:
         for key, value in kwargs.items():
-            kwargs[key] = value.to(device)
-
-        if forward_mode == 'forward':
-            _ = model(*args, **kwargs)
-        if forward_mode == 'generate':
-            _ = model.generate(*args, **kwargs)
+            if torch.is_tensor(value):
+                kwargs[key] = value.to(device)
     else:
+        kwargs = {}
         for index in range(len(args)):
             args[index] = args[index].to(device)
 
-        if forward_mode == 'forward':
-            _ = model(*args)
-        if forward_mode == 'generate':
-            _ = model.generate(*args)
+    if forward_mode == 'forward':
+        _ = model(*args, **kwargs)
+    elif forward_mode == 'generate':
+        _ = model.generate(*args, **kwargs)
+    else:
+        raise NotImplementedError("forward_mode should be either forward or generate")
 
     flops = calculate_flops_pipline.get_total_flops()
     macs = calculate_flops_pipline.get_total_macs()


### PR DESCRIPTION
Thank you for the very useful repo!

I made a small change in the code of flops_counter.calculate_flops() so that we can pass non-tensor arguments to model.generate() (e.g., kwargs = {..., max_new_tokens=10}). I couldn't figure out how to pass non-tensor arguments without changing the code. 

Other minor changes: small refactor and raise an error when forward_mode is not forward or generate, to see immediately that the runtime error is caused by e.g. a typo.