### PR TITLE
fix bug in _einsum_flops_compute when using torch.einsum

### DIFF
--- a/calflops/pytorch_ops.py
+++ b/calflops/pytorch_ops.py
@@ -292,7 +292,7 @@ def _einsum_flops_compute(equation, *operands):
     Count flops for the einsum operation.
     """
     equation = equation.replace(" ", "")
-    input_shapes = [o.shape for o in operands]
+    input_shapes = [o_element.shape for o in operands for o_element in (o if isinstance(o, list) else [o])]
 
     # Re-map equation so that same equation with different alphabet
     # representations will look the same.

--- a/calflops/pytorch_ops.py
+++ b/calflops/pytorch_ops.py
@@ -292,7 +292,7 @@ def _einsum_flops_compute(equation, *operands):
     Count flops for the einsum operation.
     """
     equation = equation.replace(" ", "")
-    input_shapes = [o_element.shape for o in operands for o_element in (o if isinstance(o, list) else [o])]
+    input_shapes = [o_element.shape for o in operands for o_element in (o if isinstance(o, (list,tuple)) else [o])]
 
     # Re-map equation so that same equation with different alphabet
     # representations will look the same.


### PR DESCRIPTION
Thank you for your excellent work!

This issue #40 gives a toy example of multi-head self-attention implemented using `torch.einsum`. Running that script gets an AttributeError raised in function `_einsum_flops_compute()`. To fix this, I made minimal modifications to the way of getting `input_shapes`  list:
```python
input_shapes = [o_element.shape for o in operands for o_element in (o if isinstance(o, list) else [o])]
```
If `o` is a list, we just collect the shapes of all its elements (`o_element`s), otherwise we get the shape of `o`.
